### PR TITLE
[FE] 헤더기능구현 및 히스토리 애니메이션 기능

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,13 +7,7 @@
     <title>Todo list</title>
   </head>
   <body>
-    <header class="header">
-      <h1 class="header_title">TO-DO LIST</h1>
-      <button class="menu_btn">
-        <img src="./src/img/menu_icon.png" alt="활동기록 메뉴" />
-      </button>
-    </header>
-    <main>
+    <!-- <main>
       <article class="todo_container">
         <section class="todo_column_box">
           <div class="column_title_box">
@@ -130,7 +124,7 @@
         </div>
       </div>
 
-      <article class="history_container show">
+      <article class="history_container">
         <ul class="history_list">
           <li class="history_card">
             <div
@@ -165,6 +159,6 @@
           <img src="./src/img/close.png" alt="close icon" />
         </button>
       </article>
-    </main>
+    </main> -->
   </body>
 </html>

--- a/frontend/src/js/Header/Model.js
+++ b/frontend/src/js/Header/Model.js
@@ -1,0 +1,13 @@
+export default class HeaderModel {
+  constructor() {
+    this.menuStatus = false;
+  }
+
+  updateStatus() {
+    this.menuStatus ? (this.menuStatus = false) : (this.menuStatus = true);
+  }
+
+  getMenuStatus() {
+    return this.menuStatus;
+  }
+}

--- a/frontend/src/js/Header/View.js
+++ b/frontend/src/js/Header/View.js
@@ -1,0 +1,13 @@
+import { headerTemplate } from '../Utils/template.js';
+
+export default class HeaderView {
+  constructor() {
+    this.render();
+  }
+
+  render() {
+    const body = document.querySelector('body');
+    const headerHtml = headerTemplate();
+    body.insertAdjacentHTML('afterbegin', headerHtml);
+  }
+}

--- a/frontend/src/js/Header/View.js
+++ b/frontend/src/js/Header/View.js
@@ -10,4 +10,10 @@ export default class HeaderView {
     const headerHtml = headerTemplate();
     body.insertAdjacentHTML('afterbegin', headerHtml);
   }
+
+  eventInit(menuBtnHandler) {
+    const menuBtn = document.querySelector('.menu_btn');
+
+    menuBtn.addEventListener('click', menuBtnHandler);
+  }
 }

--- a/frontend/src/js/Header/main.js
+++ b/frontend/src/js/Header/main.js
@@ -1,0 +1,9 @@
+import HeaderModel from './Model.js';
+import HeaderView from './View.js';
+
+export default class Header {
+  constructor() {
+    this.model = new HeaderModel();
+    this.view = new HeaderView();
+  }
+}

--- a/frontend/src/js/History/View.js
+++ b/frontend/src/js/History/View.js
@@ -13,4 +13,10 @@ export default class HistoryView {
     main.insertAdjacentHTML('afterbegin', historyContainer);
     this.historyContainer = document.querySelector('.history_container');
   }
+
+  eventInit(closeBtnHandler) {
+    const closeBtn = document.querySelector('.history_container .close_btn');
+
+    closeBtn.addEventListener('click', closeBtnHandler);
+  }
 }

--- a/frontend/src/js/History/View.js
+++ b/frontend/src/js/History/View.js
@@ -1,0 +1,16 @@
+import { historyTemplate } from '../Utils/template.js';
+
+export default class HistoryView {
+  constructor() {
+    this.historyContainer;
+
+    this.render();
+  }
+
+  render() {
+    const main = document.querySelector('main');
+    const historyContainer = historyTemplate();
+    main.insertAdjacentHTML('afterbegin', historyContainer);
+    this.historyContainer = document.querySelector('.history_container');
+  }
+}

--- a/frontend/src/js/History/View.js
+++ b/frontend/src/js/History/View.js
@@ -19,4 +19,12 @@ export default class HistoryView {
 
     closeBtn.addEventListener('click', closeBtnHandler);
   }
+
+  animation(menuStatus) {
+    if (menuStatus) {
+      this.historyContainer.classList.add('show');
+      return;
+    }
+    this.historyContainer.classList.remove('show');
+  }
 }

--- a/frontend/src/js/History/main.js
+++ b/frontend/src/js/History/main.js
@@ -1,0 +1,7 @@
+import HistoryView from './View.js';
+
+export default class History {
+  constructor() {
+    this.view = new HistoryView();
+  }
+}

--- a/frontend/src/js/Utils/template.js
+++ b/frontend/src/js/Utils/template.js
@@ -9,4 +9,44 @@ const headerTemplate = () => {
   `;
 };
 
-export { headerTemplate };
+const historyTemplate = () => {
+  return `
+  <article class="history_container">
+    <ul class="history_list">
+      <li class="history_card">
+        <div
+          class="user_img"
+          style="background-image: url(./src/img/user.svg)"
+        ></div>
+        <div class="history_text">
+          <span class="user_id">@이든</span>
+          <div class="history_content">
+            <strong>해야할 일</strong>에 <strong>TIL작성하기</strong>를
+            <strong>등록</strong>하였습니다.
+          </div>
+          <span class="history_time">1분전</span>
+        </div>
+      </li>
+      <li class="history_card">
+        <div
+          class="user_img"
+          style="background-image: url(./src/img/user.svg)"
+        ></div>
+        <div class="history_text">
+          <span class="user_id">@J</span>
+          <div class="history_content">
+            <strong>해야할 일</strong>에 <strong>HTML/CSS 작성</strong>를
+            <strong>등록</strong>하였습니다.
+          </div>
+          <span class="history_time">1분전</span>
+        </div>
+      </li>
+    </ul>
+    <button class="close_btn">
+      <img src="./src/img/close.png" alt="close icon" />
+    </button>
+  </article>
+  `;
+};
+
+export { headerTemplate, historyTemplate };

--- a/frontend/src/js/Utils/template.js
+++ b/frontend/src/js/Utils/template.js
@@ -1,0 +1,12 @@
+const headerTemplate = () => {
+  return `
+  <header class="header">
+    <h1 class="header_title">TO-DO LIST</h1>
+    <button class="menu_btn">
+      <img src="./src/img/menu_icon.png" alt="활동기록 메뉴" />
+    </button>
+  </header>
+  `;
+};
+
+export { headerTemplate };

--- a/frontend/src/js/app.js
+++ b/frontend/src/js/app.js
@@ -1,2 +1,15 @@
 import resetCss from '../scss/reset.scss';
 import css from '../scss/style.scss';
+
+import Controller from './controller.js';
+import Header from './Header/main.js';
+import History from './History/main.js';
+
+(function () {
+  const body = document.querySelector('body');
+  const mainTag = '<main></main>';
+  body.insertAdjacentHTML('afterbegin', mainTag);
+  const header = new Header();
+  const history = new History();
+  const controller = new Controller({ header, history });
+})();

--- a/frontend/src/js/controller.js
+++ b/frontend/src/js/controller.js
@@ -1,0 +1,14 @@
+export default class Controller {
+  constructor({ header }) {
+    this.header = header;
+    this.init();
+  }
+
+  init() {
+    this.header.view.eventInit(this.menuBtnClickHandler.bind(this));
+  }
+
+  menuBtnClickHandler() {
+    this.header.model.updateStatus();
+  }
+}

--- a/frontend/src/js/controller.js
+++ b/frontend/src/js/controller.js
@@ -1,14 +1,18 @@
 export default class Controller {
-  constructor({ header }) {
+  constructor({ header, history }) {
     this.header = header;
+    this.history = history;
     this.init();
   }
 
   init() {
     this.header.view.eventInit(this.menuBtnClickHandler.bind(this));
+    this.history.view.eventInit(this.menuBtnClickHandler.bind(this));
   }
 
   menuBtnClickHandler() {
     this.header.model.updateStatus();
+    const menuStatus = this.header.model.getMenuStatus();
+    this.history.view.animation(menuStatus);
   }
 }


### PR DESCRIPTION
## 🤷‍♂️ Description

- 기존 html 내용 주석처리하고 header, history 템플릿으로 작성하여 동적 생성
- 메뉴 버튼 클릭으로 히스토리 애니메이션 노출
- 히스토리 내에 닫기 버튼 클릭으로 히스토리 애니메이션 레이어 숨겨짐

헤더 메뉴 버튼 기능을 구현하며 닫기 버튼 기능이랑 같은 메서드로 사용 가능하여 히스토리 애니메이션 기능까지 구현했습니다.
html은 동적으로 들어갈 것을 생각하여 header 부분은 삭제해 두었고, 나머지는 일단 주석 처리 했습니다.
컬럼 및 카드 기능 작업까지 마무리되면 모두 삭제하면 될 것 같습니다.

## 📷 Screenshots

https://user-images.githubusercontent.com/68211156/162637306-9825eaec-0d7b-40e4-92d6-2677f174f00b.mov
