### PR TITLE
[BE] 카드 생성 시 검증 로직 추가

### DIFF
--- a/backend/src/main/java/com/codesquad/todolist/card/CardController.java
+++ b/backend/src/main/java/com/codesquad/todolist/card/CardController.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import javax.validation.Valid;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -35,6 +36,7 @@ public class CardController {
     @PostMapping
     public ResponseEntity<HistoryResponse> createCard(
         @RequestBody @Valid CardCreateRequest request) {
+        cardService.validateCreateInput(request.getColumnId(), request.getNextId());
         HistoryResponse historyResponse = cardService.create(request);
         return new ResponseEntity<>(historyResponse, HttpStatus.CREATED);
     }

--- a/backend/src/main/java/com/codesquad/todolist/card/CardController.java
+++ b/backend/src/main/java/com/codesquad/todolist/card/CardController.java
@@ -1,12 +1,5 @@
 package com.codesquad.todolist.card;
 
-import com.codesquad.todolist.card.dto.CardCreateRequest;
-import com.codesquad.todolist.card.dto.CardMoveRequest;
-import com.codesquad.todolist.card.dto.CardUpdateRequest;
-import com.codesquad.todolist.history.dto.HistoryResponse;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
 import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
@@ -19,6 +12,15 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.codesquad.todolist.card.dto.CardCreateRequest;
+import com.codesquad.todolist.card.dto.CardMoveRequest;
+import com.codesquad.todolist.card.dto.CardUpdateRequest;
+import com.codesquad.todolist.history.dto.HistoryResponse;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 @Api(tags = "Card API")
 @RestController
@@ -36,7 +38,6 @@ public class CardController {
     @PostMapping
     public ResponseEntity<HistoryResponse> createCard(
         @RequestBody @Valid CardCreateRequest request) {
-        cardService.validateCreateInput(request.getColumnId(), request.getNextId());
         HistoryResponse historyResponse = cardService.create(request);
         return new ResponseEntity<>(historyResponse, HttpStatus.CREATED);
     }

--- a/backend/src/main/java/com/codesquad/todolist/card/CardRepository.java
+++ b/backend/src/main/java/com/codesquad/todolist/card/CardRepository.java
@@ -1,9 +1,9 @@
 package com.codesquad.todolist.card;
 
-import com.codesquad.todolist.util.KeyHolderFactory;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
@@ -11,6 +11,8 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
+
+import com.codesquad.todolist.util.KeyHolderFactory;
 
 @Repository
 public class CardRepository {
@@ -42,6 +44,16 @@ public class CardRepository {
             "select card_id, column_id, title, content, author, next_id, created_date from card"
                 + " where deleted = false";
         return jdbcTemplate.query(sql, getCardRowMapper());
+    }
+
+    public List<Card> findByColumnId(Integer columnId) {
+        String sql = "select card_id, column_id, title, content, author, next_id, created_date from card"
+            + " where column_id = :columnId and deleted = false";
+
+        MapSqlParameterSource source = new MapSqlParameterSource()
+            .addValue("columnId", columnId);
+
+        return jdbcTemplate.query(sql, source, getCardRowMapper());
     }
 
     public Optional<Card> findById(int cardId) {

--- a/backend/src/main/java/com/codesquad/todolist/card/CardService.java
+++ b/backend/src/main/java/com/codesquad/todolist/card/CardService.java
@@ -1,5 +1,13 @@
 package com.codesquad.todolist.card;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
 import com.codesquad.todolist.card.dto.CardCreateRequest;
 import com.codesquad.todolist.card.dto.CardMoveRequest;
 import com.codesquad.todolist.card.dto.CardUpdateRequest;
@@ -10,8 +18,6 @@ import com.codesquad.todolist.history.domain.Field;
 import com.codesquad.todolist.history.domain.History;
 import com.codesquad.todolist.history.domain.ModifiedField;
 import com.codesquad.todolist.history.dto.HistoryResponse;
-import java.util.List;
-import org.springframework.stereotype.Service;
 
 @Service
 public class CardService {
@@ -120,6 +126,25 @@ public class CardService {
 
         if (count == 0) {
             throw new IllegalStateException("해당 컬럼에서 다음 카드를 찾을 수 없습니다.");
+        }
+    }
+
+    public void validateCreateInput(Integer columnId, Integer nextId) {
+        List<Card> cards = cardRepository.findByColumnId(columnId);
+        if (cards.size() == 0 && nextId == null) {
+            return;
+        }
+        Map<Integer, Card> columnCardMap = cards.stream()
+            .collect(Collectors.toMap(Card::getNextId, Function.identity()));
+        Card card = Optional.ofNullable(columnCardMap.remove(null))
+            .orElseThrow(() -> new IllegalArgumentException("조건을 만족하는 카드가 없습니다."));
+
+        while (columnCardMap.size() > 0) {
+            card = columnCardMap.remove(card.getCardId());
+        }
+
+        if (!card.getCardId().equals(nextId)) {
+            throw new IllegalStateException("조건을 만족하는 카드가 없습니다.");
         }
     }
 }

--- a/backend/src/main/java/com/codesquad/todolist/card/CardService.java
+++ b/backend/src/main/java/com/codesquad/todolist/card/CardService.java
@@ -34,7 +34,8 @@ public class CardService {
     }
 
     public HistoryResponse create(CardCreateRequest request) {
-        Card card = request.toEntity();
+        Integer nextId = findNextId(request.getColumnId());
+        Card card = request.toEntity(nextId);
         cardRepository.create(card);
 
         // History 저장
@@ -129,10 +130,10 @@ public class CardService {
         }
     }
 
-    public void validateCreateInput(Integer columnId, Integer nextId) {
+    public Integer findNextId(Integer columnId) {
         List<Card> cards = cardRepository.findByColumnId(columnId);
-        if (cards.size() == 0 && nextId == null) {
-            return;
+        if (cards.size() == 0) {
+            return null;
         }
         Map<Integer, Card> columnCardMap = cards.stream()
             .collect(Collectors.toMap(Card::getNextId, Function.identity()));
@@ -143,8 +144,6 @@ public class CardService {
             card = columnCardMap.remove(card.getCardId());
         }
 
-        if (!card.getCardId().equals(nextId)) {
-            throw new IllegalStateException("조건을 만족하는 카드가 없습니다.");
-        }
+        return card.getCardId();
     }
 }

--- a/backend/src/main/java/com/codesquad/todolist/card/dto/CardCreateRequest.java
+++ b/backend/src/main/java/com/codesquad/todolist/card/dto/CardCreateRequest.java
@@ -1,8 +1,10 @@
 package com.codesquad.todolist.card.dto;
 
-import com.codesquad.todolist.card.Card;
-import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotNull;
+
+import com.codesquad.todolist.card.Card;
+
+import io.swagger.annotations.ApiModelProperty;
 
 public class CardCreateRequest {
 
@@ -22,23 +24,17 @@ public class CardCreateRequest {
     @NotNull(message = "author 값이 있어야 합니다.")
     private String author;
 
-    @ApiModelProperty(value = "목표 컬럼의 최상위 카드 Id")
-    @NotNull(message = "nextId 값이 있어야 합니다.")
-    private Integer nextId;
-
     private CardCreateRequest() {
     }
 
-    public CardCreateRequest(Integer columnId, String title, String author, String content,
-        Integer nextId) {
+    public CardCreateRequest(Integer columnId, String title, String author, String content) {
         this.columnId = columnId;
         this.title = title;
         this.content = content;
         this.author = author;
-        this.nextId = nextId;
     }
 
-    public Card toEntity() {
+    public Card toEntity(Integer nextId) {
         return new Card(columnId, title, content, author, nextId);
     }
 
@@ -58,10 +54,6 @@ public class CardCreateRequest {
         return author;
     }
 
-    public Integer getNextId() {
-        return nextId;
-    }
-
     @Override
     public String toString() {
         return "CardCreateRequest{" +
@@ -69,7 +61,6 @@ public class CardCreateRequest {
             ", title='" + title + '\'' +
             ", content='" + content + '\'' +
             ", author='" + author + '\'' +
-            ", nextId=" + nextId +
             '}';
     }
 }

--- a/backend/src/test/java/com/codesquad/todolist/card/unit/CardControllerTest.java
+++ b/backend/src/test/java/com/codesquad/todolist/card/unit/CardControllerTest.java
@@ -34,7 +34,7 @@ public class CardControllerTest {
     @DisplayName("카드를 생성하는 요청이 오면 카드가 생성된다")
     public void cardCreateTest() throws Exception {
         // given
-        CardCreateRequest request = new CardCreateRequest(1, "제목", "작성자", "내용", null);
+        CardCreateRequest request = new CardCreateRequest(1, "제목", "작성자", "내용");
 
         // when
         ResultActions actions = mockMvc.perform(post("/cards")

--- a/backend/src/test/java/com/codesquad/todolist/card/unit/CardServiceTest.java
+++ b/backend/src/test/java/com/codesquad/todolist/card/unit/CardServiceTest.java
@@ -1,10 +1,17 @@
 package com.codesquad.todolist.card.unit;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.BDDMockito.times;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.codesquad.todolist.card.Card;
 import com.codesquad.todolist.card.CardRepository;
@@ -12,14 +19,6 @@ import com.codesquad.todolist.card.CardService;
 import com.codesquad.todolist.card.dto.CardCreateRequest;
 import com.codesquad.todolist.card.dto.CardMoveRequest;
 import com.codesquad.todolist.card.dto.CardUpdateRequest;
-import java.time.LocalDateTime;
-import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CardService 단위 테스트")
@@ -50,7 +49,7 @@ public class CardServiceTest {
     @DisplayName("카드 생성시 저장소에 카드 데이터가 저장된다")
     public void cardCreateTest() {
         // given
-        CardCreateRequest createRequest = new CardCreateRequest(1, "제목", "작성자", "내용", null);
+        CardCreateRequest createRequest = new CardCreateRequest(1, "제목", "작성자", "내용");
         Card card = new Card(1, "제목", "내용", "작성자", 1);
 
         given(cardRepository.create(any(Card.class))).willReturn(card);


### PR DESCRIPTION

## 🤷‍♂️ Description
카드 생성 시 RequestBody로 입력된 columnId 와 nextId 가 적합한지 검증하는 로직을 추가하였습니다.

<!-- 변경사항과 해결된 문제를 요약해서 첨부해 주세요. 관련된 상황을 서술하거나 이미지를 첨부하셔도 좋습니다. -->


<!-- 세부 구현 사항을 리스트로 작성해주세요. -->
- 예시) 2번 컬럼에 있는 5번카드 위에 새 카드를 생성하는데 만약 columnId=1, nextId=5가 입력될 경우 에러를 발생시키도록 한다.


<!--스크린샷으로 보여줄 수 있는 이미지가 있다면 첨부해주세요!-->



<!--마지막으로 PR 생성 시 우측의 옵션들을 체크했는지 확인해주세요!-->
