### PR TITLE
[FE] 카드 삭제 기능 구현

### DIFF
--- a/frontend/src/js/Alert/AlertView.js
+++ b/frontend/src/js/Alert/AlertView.js
@@ -29,7 +29,7 @@ class AlertView {
       className: 'todo_container',
     });
 
-    $todo_container.insertAdjacentElement('afterend', this.$alert_container);
+    $todo_container?.insertAdjacentElement('afterend', this.$alert_container);
   }
 
   render() {

--- a/frontend/src/js/Controller/Controller.js
+++ b/frontend/src/js/Controller/Controller.js
@@ -10,6 +10,8 @@ class Controller {
     this.todo = null;
     this.deleteAlertView = null;
     this.newCard = null;
+    this.deletedCard = null;
+    this.deletedColumn = null;
     this.init();
   }
 
@@ -30,19 +32,31 @@ class Controller {
     this.initTodo();
   }
 
-  initAlert({ target, content }) {
-    target = new AlertView(content);
-
-    target.onClickCancel(handleClickCancel);
-    target.onClickAccept(handleClickAccept);
+  initAlert() {
+    this.deleteAlertView = new AlertView({
+      title: '선택한 카드를 삭제할까요?',
+      cancel: '취소',
+      accept: '삭제',
+    });
+    this.deleteAlertView.onClickCancel(handleClickCancel.bind(this));
+    this.deleteAlertView.onClickAccept(handleClickAccept.bind(this));
 
     function handleClickCancel() {
-      target.render();
+      this.deleteAlertView.render();
     }
 
     function handleClickAccept() {
-      // Todo: 추후 로직 추가
-      target.render();
+      const targetColumn = this.todo.model.columns[this.deletedColumn.id];
+      const targetCard = targetColumn.model.cardList[this.deletedCard.id];
+      targetCard.view.renderDeleted(this.deletedCard);
+
+      targetColumn.model.deleteCard(this.deletedCard.id);
+      targetColumn.model.updateCardCount();
+      targetColumn.view.renderCardCount(
+        this.deletedColumn,
+        targetColumn.model.cardCount
+      );
+      this.deleteAlertView.render();
     }
   }
 
@@ -80,6 +94,7 @@ class Controller {
       cardInputHandler: this.cardInputHandler.bind(this),
       cardAddHandler: this.cardAddHandler.bind(this),
       cardCancelHandler: this.cardCancelHandler.bind(this),
+      cardDeleteHandler: this.cardDeleteHandler.bind(this),
     });
   }
 
@@ -141,8 +156,18 @@ class Controller {
     if (targetCard.classList.contains('edit')) {
       return;
     }
+
     this.cancelAddCard(targetColumnBox);
     targetColumn.model.updateAddStstue();
+  }
+
+  cardDeleteHandler({ target }) {
+    const { targetColumnBox, targetCard } = this.getTargetCardInfo(target);
+    this.deletedColumn = targetColumnBox;
+    this.deletedCard = targetCard;
+
+    targetCard.classList.add('delete_hover');
+    this.deleteAlertView.$alert_container.classList.remove('hidden');
   }
 
   getTargetCardInfo(target) {

--- a/frontend/src/js/Todo/Card/View.js
+++ b/frontend/src/js/Todo/Card/View.js
@@ -4,13 +4,20 @@ import { cardTemplate } from '../../utils/template';
 export default class CardView {
   constructor() {}
 
-  eventInit({ cardInputHandler, cardAddHandler, cardCancelHandler }) {
+  eventInit({
+    cardInputHandler,
+    cardAddHandler,
+    cardCancelHandler,
+    cardDeleteHandler,
+  }) {
     const writeCard = document.querySelector('.card.write');
     const accentBtn = writeCard.querySelector('.accent_btn');
     const cancelBtn = writeCard.querySelector('.normal_btn');
+    const deleteBtn = writeCard.querySelector('.delete_btn');
     writeCard.addEventListener('input', cardInputHandler);
     accentBtn.addEventListener('click', cardAddHandler);
     cancelBtn.addEventListener('click', cardCancelHandler);
+    deleteBtn.addEventListener('click', cardDeleteHandler);
   }
 
   renderAddCard(targetColumn, cardId) {
@@ -20,5 +27,9 @@ export default class CardView {
       className: 'card_list',
     });
     targetList.insertAdjacentHTML('afterbegin', cardHtml);
+  }
+
+  renderDeleted(card) {
+    card.remove();
   }
 }

--- a/frontend/src/js/Todo/Column/Model.js
+++ b/frontend/src/js/Todo/Column/Model.js
@@ -16,6 +16,10 @@ export default class ColumnModel {
     this.updateCardCount();
   }
 
+  deleteCard(cardId) {
+    delete this.cardList[cardId];
+  }
+
   updateCardCount() {
     this.cardCount = Object.keys(this.cardList).length;
   }

--- a/frontend/src/js/app.js
+++ b/frontend/src/js/app.js
@@ -8,14 +8,7 @@ import { History } from './History/main.js';
 
 (function () {
   const controller = new Controller({ Header, History });
-  controller.initAlert({
-    target: controller.deleteAlertView,
-    content: {
-      title: '선택한 카드를 삭제할까요?',
-      cancel: '취소',
-      accept: '삭제',
-    },
-  });
+  controller.initAlert();
 })();
 
 // dragNdrop();


### PR DESCRIPTION
## 🤷‍♂️ Description

- [x] 카드 삭제 버튼을 누르면 삭체 알림창 표시
- [x] 삭제 알림창의 삭제 버튼을 누르면 카드 데이터 삭제 
- [x] 삭제 알림창의 삭제 버튼을 누르면 카드 요소 DOM에서 삭제
- [x] 칼럼의 count수도 -1하여 렌더
- [x] 삭제 알림창의 취소 버튼을 누르면 알림창 끄기 

## 📷 Screenshots

https://user-images.githubusercontent.com/58525009/163307463-14011928-cf70-4a7e-be97-58992d601eca.mp4
