### PR TITLE
[BE] Update 시 PUT 대신 PATCH 방식을 사용하도록 변경

### DIFF
--- a/backend/src/main/java/com/codesquad/todolist/card/Card.java
+++ b/backend/src/main/java/com/codesquad/todolist/card/Card.java
@@ -1,10 +1,11 @@
 package com.codesquad.todolist.card;
 
-import com.codesquad.todolist.history.domain.Field;
-import com.codesquad.todolist.history.domain.ModifiedField;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.codesquad.todolist.history.domain.Field;
+import com.codesquad.todolist.history.domain.ModifiedField;
 
 public class Card implements Cloneable {
 
@@ -36,15 +37,15 @@ public class Card implements Cloneable {
     }
 
     public void update(String title, String content, String author) {
-        if (!this.title.equals(title)) {
+        if (title != null && !this.title.equals(title)) {
             modifiedFields.add(new ModifiedField(Field.TITLE, this.title, title));
             this.title = title;
         }
-        if (!this.content.equals(content)) {
+        if (content != null && !this.content.equals(content)) {
             modifiedFields.add(new ModifiedField(Field.CONTENT, this.content, content));
             this.content = content;
         }
-        if (!this.author.equals(author)) {
+        if (author != null && !this.author.equals(author)) {
             modifiedFields.add(new ModifiedField(Field.AUTHOR, this.author, author));
             this.author = author;
         }
@@ -57,6 +58,10 @@ public class Card implements Cloneable {
 
     public Integer getCardId() {
         return cardId;
+    }
+
+    public void setCardId(int cardId) {
+        this.cardId = cardId;
     }
 
     public Integer getColumnId() {
@@ -87,14 +92,10 @@ public class Card implements Cloneable {
         return modifiedFields;
     }
 
-    public void setCardId(int cardId) {
-        this.cardId = cardId;
-    }
-
     @Override
     public Card clone() {
         try {
-            return (Card) super.clone();
+            return (Card)super.clone();
         } catch (CloneNotSupportedException e) {
             return null;
         }

--- a/backend/src/main/java/com/codesquad/todolist/card/CardController.java
+++ b/backend/src/main/java/com/codesquad/todolist/card/CardController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -43,7 +44,7 @@ public class CardController {
     }
 
     @ApiOperation(value = "카드 업데이트", notes = "지정한 카드를 새로운 데이터로 업데이트합니다.")
-    @PutMapping("/{id}")
+    @PatchMapping("/{id}")
     public HistoryResponse updateCard(
         @ApiParam(name = "id", value = "업데이트할 카드 Id", required = true)
         @PathVariable(value = "id") Integer cardId,

--- a/backend/src/main/java/com/codesquad/todolist/card/dto/CardUpdateRequest.java
+++ b/backend/src/main/java/com/codesquad/todolist/card/dto/CardUpdateRequest.java
@@ -1,20 +1,16 @@
 package com.codesquad.todolist.card.dto;
 
 import io.swagger.annotations.ApiModelProperty;
-import javax.validation.constraints.NotNull;
 
 public class CardUpdateRequest {
 
     @ApiModelProperty(value = "카드의 제목")
-    @NotNull(message = "title 값이 있어야 합니다.")
     private String title;
 
     @ApiModelProperty(value = "카드의 내용")
-    @NotNull(message = "content 값이 있어야 합니다.")
     private String content;
 
     @ApiModelProperty(value = "작성자")
-    @NotNull(message = "author 값이 있어야 합니다.")
     private String author;
 
     private CardUpdateRequest() {


### PR DESCRIPTION

## 🤷‍♂️ Description
카드 업데이트 요청 시 요청 메서드를 PATCH 방식으로 변경하였습니다.
<!-- 변경사항과 해결된 문제를 요약해서 첨부해 주세요. 관련된 상황을 서술하거나 이미지를 첨부하셔도 좋습니다. -->



<!-- 세부 구현 사항을 리스트로 작성해주세요. -->

- 기존에는 제목, 내용, 작성자 중 하나만 바꾸더라도 세 개의 필드 값을 모두 RequestBody에 담았어야 했으나,
PATCH 방식으로 바꿈으로써 변경하는 필드 데이터만 보내주면 되도록 변경하였습니다.

기존 PUT 방식으로 content 수정 요청 시 RequestBody
```
{
  "title": "원래 제목",
  "content": "수정된 내용",
  "author": "원래 작성자"
}
```
PATCH 방식으로 변경 후
```
{
  "content": "수정된 내용"
}
```